### PR TITLE
Refactor environment handlers to standard responses

### DIFF
--- a/src/tools/Environments/Fork/handlers/forkEnvironmentHandler.ts
+++ b/src/tools/Environments/Fork/handlers/forkEnvironmentHandler.ts
@@ -5,8 +5,12 @@
 
 import type { z } from "zod";
 import { getClient } from "../../../../utils/clientManager.js";
-import { createResponse } from "../../../../utils/responseHandlers.js";
-import { isAuthorizationError, isNotFoundError, createErrorResponse , extractDetailedErrorInfo } from "../../../../utils/errorHandlers.js";
+import {
+  createStandardSuccessResponse,
+  createStandardErrorResponse,
+  createStandardMcpResponse
+} from "../../../../utils/standardResponse.js";
+import { isAuthorizationError, isNotFoundError, extractDetailedErrorInfo } from "../../../../utils/errorHandlers.js";
 import type { environmentSchemas } from "../../schemas.js";
 
 /**
@@ -30,26 +34,43 @@ export const forkEnvironmentHandler = async (args: z.infer<typeof environmentSch
       };
       
       const environment = await client.environments.fork(environmentId, forkOptions);
-      
+
       if (!environment) {
-        return createErrorResponse(`Error: Failed to fork environment with ID '${environmentId}'.`);
+        const response = createStandardErrorResponse(
+          `Failed to fork environment with ID '${environmentId}'.`,
+          { error_code: "ENVIRONMENT_NOT_FOUND" }
+        );
+        return createStandardMcpResponse(response);
       }
-      
-      return createResponse(JSON.stringify(environment, null, 2));
+
+      const response = createStandardSuccessResponse(environment as any);
+      return createStandardMcpResponse(response);
       
     } catch (apiError: unknown) {
       if (isAuthorizationError(apiError)) {
-        return createErrorResponse("Error: Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.");
+        const response = createStandardErrorResponse(
+          "Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.",
+          { error_code: "INVALID_API_TOKEN" }
+        );
+        return createStandardMcpResponse(response);
       }
-      
+
       if (isNotFoundError(apiError)) {
-        return createErrorResponse(`Error: Environment with ID '${environmentId}' was not found.`);
+        const response = createStandardErrorResponse(
+          `Environment with ID '${environmentId}' was not found.`,
+          { error_code: "ENVIRONMENT_NOT_FOUND" }
+        );
+        return createStandardMcpResponse(response);
       }
-      
+
       // Re-throw other API errors to be caught by the outer catch
-      throw apiError;
+      const response = createStandardErrorResponse(apiError);
+      return createStandardMcpResponse(response);
     }
   } catch (error: unknown) {
-    return createErrorResponse(`Error forking environment: ${extractDetailedErrorInfo(error)}`);
+    const response = createStandardErrorResponse(
+      `Error forking environment: ${extractDetailedErrorInfo(error)}`
+    );
+    return createStandardMcpResponse(response);
   }
 };

--- a/src/tools/Environments/List/ListDatoCMSEnvironments.ts
+++ b/src/tools/Environments/List/ListDatoCMSEnvironments.ts
@@ -1,7 +1,11 @@
 import { z } from "zod";
 import { getClient } from "../../../utils/clientManager.js";
-import { isAuthorizationError, createErrorResponse , extractDetailedErrorInfo } from "../../../utils/errorHandlers.js";
-import { createResponse } from "../../../utils/responseHandlers.js";
+import { isAuthorizationError, extractDetailedErrorInfo } from "../../../utils/errorHandlers.js";
+import {
+  createStandardSuccessResponse,
+  createStandardErrorResponse,
+  createStandardMcpResponse
+} from "../../../utils/standardResponse.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 /**
@@ -30,29 +34,34 @@ export const registerListDatoCMSEnvironments = (server: McpServer) => {
         try {
           // List all environments
           const environments = await client.environments.list();
-          
+
           if (!environments || environments.length === 0) {
-            return createResponse(JSON.stringify([], null, 2));
+            const response = createStandardSuccessResponse<any[]>([], "No environments found.");
+            return createStandardMcpResponse(response);
           }
-          
-          return createResponse(JSON.stringify(environments, null, 2));
+
+          const response = createStandardSuccessResponse(environments as any[], `Found ${environments.length} environment(s).`);
+          return createStandardMcpResponse(response);
           
         } catch (apiError: unknown) {
           if (isAuthorizationError(apiError)) {
-            return createErrorResponse("Error: Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.");
+            const response = createStandardErrorResponse(
+              "Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.",
+              { error_code: "INVALID_API_TOKEN" }
+            );
+            return createStandardMcpResponse(response);
           }
-          
-          // Re-throw other API errors to be caught by the outer catch
-          throw apiError;
+
+          const response = createStandardErrorResponse(apiError);
+          return createStandardMcpResponse(response);
         }
       } catch (error: unknown) {
-        return {
-          content: [{
-            type: "text" as const,
-            text: `Error listing environments: ${extractDetailedErrorInfo(error)}`
-          }]
-        };
+        const response = createStandardErrorResponse(
+          `Error listing environments: ${extractDetailedErrorInfo(error)}`
+        );
+        return createStandardMcpResponse(response);
       }
     }
   );
 };
+

--- a/src/tools/Environments/List/handlers/listEnvironmentsHandler.ts
+++ b/src/tools/Environments/List/handlers/listEnvironmentsHandler.ts
@@ -5,8 +5,12 @@
 
 import type { z } from "zod";
 import { getClient } from "../../../../utils/clientManager.js";
-import { createResponse } from "../../../../utils/responseHandlers.js";
-import { isAuthorizationError, createErrorResponse , extractDetailedErrorInfo } from "../../../../utils/errorHandlers.js";
+import {
+  createStandardSuccessResponse,
+  createStandardErrorResponse,
+  createStandardMcpResponse
+} from "../../../../utils/standardResponse.js";
+import { isAuthorizationError, extractDetailedErrorInfo } from "../../../../utils/errorHandlers.js";
 import type { environmentSchemas } from "../../schemas.js";
 
 /**
@@ -22,22 +26,32 @@ export const listEnvironmentsHandler = async (args: z.infer<typeof environmentSc
     try {
       // List all environments
       const environments = await client.environments.list();
-      
+
       if (!environments || environments.length === 0) {
-        return createResponse(JSON.stringify([], null, 2));
+        const response = createStandardSuccessResponse<any[]>([], "No environments found.");
+        return createStandardMcpResponse(response);
       }
-      
-      return createResponse(JSON.stringify(environments, null, 2));
+
+      const response = createStandardSuccessResponse(environments as any[], `Found ${environments.length} environment(s).`);
+      return createStandardMcpResponse(response);
       
     } catch (apiError: unknown) {
       if (isAuthorizationError(apiError)) {
-        return createErrorResponse("Error: Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.");
+        const response = createStandardErrorResponse(
+          "Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.",
+          { error_code: "INVALID_API_TOKEN" }
+        );
+        return createStandardMcpResponse(response);
       }
-      
+
       // Re-throw other API errors to be caught by the outer catch
-      throw apiError;
+      const response = createStandardErrorResponse(apiError);
+      return createStandardMcpResponse(response);
     }
   } catch (error: unknown) {
-    return createErrorResponse(`Error listing environments: ${extractDetailedErrorInfo(error)}`);
+    const response = createStandardErrorResponse(
+      `Error listing environments: ${extractDetailedErrorInfo(error)}`
+    );
+    return createStandardMcpResponse(response);
   }
 };

--- a/src/tools/Environments/Maintenance/handlers/activateMaintenanceModeHandler.ts
+++ b/src/tools/Environments/Maintenance/handlers/activateMaintenanceModeHandler.ts
@@ -5,8 +5,12 @@
 
 import type { z } from "zod";
 import { getClient } from "../../../../utils/clientManager.js";
-import { createResponse } from "../../../../utils/responseHandlers.js";
-import { isAuthorizationError, createErrorResponse , extractDetailedErrorInfo } from "../../../../utils/errorHandlers.js";
+import {
+  createStandardSuccessResponse,
+  createStandardErrorResponse,
+  createStandardMcpResponse
+} from "../../../../utils/standardResponse.js";
+import { isAuthorizationError, extractDetailedErrorInfo } from "../../../../utils/errorHandlers.js";
 import type { environmentSchemas } from "../../schemas.js";
 
 /**
@@ -23,22 +27,32 @@ export const activateMaintenanceModeHandler = async (args: z.infer<typeof enviro
       // Activate maintenance mode
       const options = { force };
       const maintenanceMode = await client.maintenanceMode.activate(options);
-      
+
       if (!maintenanceMode) {
-        return createErrorResponse("Error: Failed to activate maintenance mode.");
+        const response = createStandardErrorResponse("Failed to activate maintenance mode.");
+        return createStandardMcpResponse(response);
       }
-      
-      return createResponse(JSON.stringify(maintenanceMode, null, 2));
+
+      const response = createStandardSuccessResponse(maintenanceMode as any);
+      return createStandardMcpResponse(response);
       
     } catch (apiError: unknown) {
       if (isAuthorizationError(apiError)) {
-        return createErrorResponse("Error: Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.");
+        const response = createStandardErrorResponse(
+          "Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.",
+          { error_code: "INVALID_API_TOKEN" }
+        );
+        return createStandardMcpResponse(response);
       }
-      
+
       // Re-throw other API errors to be caught by the outer catch
-      throw apiError;
+      const response = createStandardErrorResponse(apiError);
+      return createStandardMcpResponse(response);
     }
   } catch (error: unknown) {
-    return createErrorResponse(`Error activating maintenance mode: ${extractDetailedErrorInfo(error)}`);
+    const response = createStandardErrorResponse(
+      `Error activating maintenance mode: ${extractDetailedErrorInfo(error)}`
+    );
+    return createStandardMcpResponse(response);
   }
 };

--- a/src/tools/Environments/Maintenance/handlers/fetchMaintenanceModeHandler.ts
+++ b/src/tools/Environments/Maintenance/handlers/fetchMaintenanceModeHandler.ts
@@ -5,8 +5,12 @@
 
 import type { z } from "zod";
 import { getClient } from "../../../../utils/clientManager.js";
-import { createResponse } from "../../../../utils/responseHandlers.js";
-import { isAuthorizationError, createErrorResponse , extractDetailedErrorInfo } from "../../../../utils/errorHandlers.js";
+import {
+  createStandardSuccessResponse,
+  createStandardErrorResponse,
+  createStandardMcpResponse
+} from "../../../../utils/standardResponse.js";
+import { isAuthorizationError, extractDetailedErrorInfo } from "../../../../utils/errorHandlers.js";
 import type { environmentSchemas } from "../../schemas.js";
 
 /**
@@ -22,22 +26,32 @@ export const fetchMaintenanceModeHandler = async (args: z.infer<typeof environme
     try {
       // Fetch maintenance mode status
       const maintenanceMode = await client.maintenanceMode.find();
-      
+
       if (!maintenanceMode) {
-        return createErrorResponse("Error: Failed to fetch maintenance mode status.");
+        const response = createStandardErrorResponse("Failed to fetch maintenance mode status.");
+        return createStandardMcpResponse(response);
       }
-      
-      return createResponse(JSON.stringify(maintenanceMode, null, 2));
+
+      const response = createStandardSuccessResponse(maintenanceMode as any);
+      return createStandardMcpResponse(response);
       
     } catch (apiError: unknown) {
       if (isAuthorizationError(apiError)) {
-        return createErrorResponse("Error: Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.");
+        const response = createStandardErrorResponse(
+          "Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.",
+          { error_code: "INVALID_API_TOKEN" }
+        );
+        return createStandardMcpResponse(response);
       }
-      
+
       // Re-throw other API errors to be caught by the outer catch
-      throw apiError;
+      const response = createStandardErrorResponse(apiError);
+      return createStandardMcpResponse(response);
     }
   } catch (error: unknown) {
-    return createErrorResponse(`Error fetching maintenance mode status: ${extractDetailedErrorInfo(error)}`);
+    const response = createStandardErrorResponse(
+      `Error fetching maintenance mode status: ${extractDetailedErrorInfo(error)}`
+    );
+    return createStandardMcpResponse(response);
   }
 };

--- a/src/tools/Environments/Read/handlers/listEnvironmentsHandler.ts
+++ b/src/tools/Environments/Read/handlers/listEnvironmentsHandler.ts
@@ -5,8 +5,12 @@
 
 import type { z } from "zod";
 import { getClient } from "../../../../utils/clientManager.js";
-import { createResponse } from "../../../../utils/responseHandlers.js";
-import { isAuthorizationError, createErrorResponse , extractDetailedErrorInfo } from "../../../../utils/errorHandlers.js";
+import {
+  createStandardSuccessResponse,
+  createStandardErrorResponse,
+  createStandardMcpResponse
+} from "../../../../utils/standardResponse.js";
+import { isAuthorizationError, extractDetailedErrorInfo } from "../../../../utils/errorHandlers.js";
 import type { environmentSchemas } from "../../schemas.js";
 
 /**
@@ -14,7 +18,7 @@ import type { environmentSchemas } from "../../schemas.js";
  */
 export const listEnvironmentsHandler = async (args: z.infer<typeof environmentSchemas.list>) => {
   const { apiToken } = args;
-  
+
   try {
     // Initialize DatoCMS client
     const client = getClient(apiToken);
@@ -24,20 +28,30 @@ export const listEnvironmentsHandler = async (args: z.infer<typeof environmentSc
       const environments = await client.environments.list();
       
       if (!environments || environments.length === 0) {
-        return createResponse(JSON.stringify([], null, 2));
+        const response = createStandardSuccessResponse<any[]>([], "No environments found.");
+        return createStandardMcpResponse(response);
       }
-      
-      return createResponse(JSON.stringify(environments, null, 2));
-      
+
+      const response = createStandardSuccessResponse(environments as any[], `Found ${environments.length} environment(s).`);
+      return createStandardMcpResponse(response);
+
     } catch (apiError: unknown) {
       if (isAuthorizationError(apiError)) {
-        return createErrorResponse("Error: Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.");
+        const response = createStandardErrorResponse(
+          "Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.",
+          { error_code: "INVALID_API_TOKEN" }
+        );
+        return createStandardMcpResponse(response);
       }
-      
+
       // Re-throw other API errors to be caught by the outer catch
-      throw apiError;
+      const response = createStandardErrorResponse(apiError);
+      return createStandardMcpResponse(response);
     }
   } catch (error: unknown) {
-    return createErrorResponse(`Error listing environments: ${extractDetailedErrorInfo(error)}`);
+    const response = createStandardErrorResponse(
+      `Error listing environments: ${extractDetailedErrorInfo(error)}`
+    );
+    return createStandardMcpResponse(response);
   }
 };

--- a/src/tools/Environments/Retrieve/handlers/retrieveEnvironmentHandler.ts
+++ b/src/tools/Environments/Retrieve/handlers/retrieveEnvironmentHandler.ts
@@ -5,8 +5,12 @@
 
 import type { z } from "zod";
 import { getClient } from "../../../../utils/clientManager.js";
-import { createResponse } from "../../../../utils/responseHandlers.js";
-import { isAuthorizationError, isNotFoundError, createErrorResponse , extractDetailedErrorInfo } from "../../../../utils/errorHandlers.js";
+import {
+  createStandardSuccessResponse,
+  createStandardErrorResponse,
+  createStandardMcpResponse
+} from "../../../../utils/standardResponse.js";
+import { isAuthorizationError, isNotFoundError, extractDetailedErrorInfo } from "../../../../utils/errorHandlers.js";
 import type { environmentSchemas } from "../../schemas.js";
 
 /**
@@ -22,26 +26,43 @@ export const retrieveEnvironmentHandler = async (args: z.infer<typeof environmen
     try {
       // Fetch environment information
       const environment = await client.environments.find(environmentId as string);
-      
+
       if (!environment) {
-        return createErrorResponse(`Error: Failed to fetch environment with ID '${environmentId}'.`);
+        const response = createStandardErrorResponse(
+          `Failed to fetch environment with ID '${environmentId}'.`,
+          { error_code: "ENVIRONMENT_NOT_FOUND" }
+        );
+        return createStandardMcpResponse(response);
       }
-      
-      return createResponse(JSON.stringify(environment, null, 2));
+
+      const response = createStandardSuccessResponse(environment as any);
+      return createStandardMcpResponse(response);
       
     } catch (apiError: unknown) {
       if (isAuthorizationError(apiError)) {
-        return createErrorResponse("Error: Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.");
+        const response = createStandardErrorResponse(
+          "Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.",
+          { error_code: "INVALID_API_TOKEN" }
+        );
+        return createStandardMcpResponse(response);
       }
-      
+
       if (isNotFoundError(apiError)) {
-        return createErrorResponse(`Error: Environment with ID '${environmentId}' was not found.`);
+        const response = createStandardErrorResponse(
+          `Environment with ID '${environmentId}' was not found.`,
+          { error_code: "ENVIRONMENT_NOT_FOUND" }
+        );
+        return createStandardMcpResponse(response);
       }
-      
+
       // Re-throw other API errors to be caught by the outer catch
-      throw apiError;
+      const response = createStandardErrorResponse(apiError);
+      return createStandardMcpResponse(response);
     }
   } catch (error: unknown) {
-    return createErrorResponse(`Error retrieving environment: ${extractDetailedErrorInfo(error)}`);
+    const response = createStandardErrorResponse(
+      `Error retrieving environment: ${extractDetailedErrorInfo(error)}`
+    );
+    return createStandardMcpResponse(response);
   }
 };

--- a/src/tools/Environments/Update/RenameDatoCMSEnvironment.ts
+++ b/src/tools/Environments/Update/RenameDatoCMSEnvironment.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
-import { isAuthorizationError, isNotFoundError, createErrorResponse, extractDetailedErrorInfo } from "../../../utils/errorHandlers.js";
-import { createResponse } from "../../../utils/responseHandlers.js";
+import { isAuthorizationError, isNotFoundError, extractDetailedErrorInfo } from "../../../utils/errorHandlers.js";
+import {
+  createStandardSuccessResponse,
+  createStandardErrorResponse,
+  createStandardMcpResponse
+} from "../../../utils/standardResponse.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { McpResponse } from "../environmentTypes.js";
 import { createEnvironmentClient } from "../environmentClient.js";
@@ -37,33 +41,45 @@ export const registerRenameDatoCMSEnvironment = (server: McpServer) => {
           const environment = await environmentClient.renameEnvironment(environmentId, {
             id: newId
           });
-          
+
           if (!environment) {
-            return createErrorResponse(`Error: Failed to rename environment with ID '${environmentId}'.`);
+            const response = createStandardErrorResponse(
+              `Failed to rename environment with ID '${environmentId}'.`,
+              { error_code: "ENVIRONMENT_NOT_FOUND" }
+            );
+            return createStandardMcpResponse(response);
           }
-          
-          return createResponse(JSON.stringify(environment, null, 2));
+
+          const response = createStandardSuccessResponse(environment as any);
+          return createStandardMcpResponse(response);
           
         } catch (apiError: unknown) {
           if (isAuthorizationError(apiError)) {
-            return createErrorResponse("Error: Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.");
+            const response = createStandardErrorResponse(
+              "Please provide a valid DatoCMS API token. The token you provided was rejected by the DatoCMS API.",
+              { error_code: "INVALID_API_TOKEN" }
+            );
+            return createStandardMcpResponse(response);
           }
-          
+
           if (isNotFoundError(apiError)) {
-            return createErrorResponse(`Error: Environment with ID '${environmentId}' was not found.`);
+            const response = createStandardErrorResponse(
+              `Environment with ID '${environmentId}' was not found.`,
+              { error_code: "ENVIRONMENT_NOT_FOUND" }
+            );
+            return createStandardMcpResponse(response);
           }
-          
-          // Re-throw other API errors to be caught by the outer catch
-          throw apiError;
+
+          const response = createStandardErrorResponse(apiError);
+          return createStandardMcpResponse(response);
         }
       } catch (error: unknown) {
-        return {
-          content: [{
-            type: "text" as const,
-            text: `Error renaming environment: ${extractDetailedErrorInfo(error)}`
-          }]
-        };
+        const response = createStandardErrorResponse(
+          `Error renaming environment: ${extractDetailedErrorInfo(error)}`
+        );
+        return createStandardMcpResponse(response);
       }
     }
   );
 };
+


### PR DESCRIPTION
## Summary
- refactor environment handlers to use standard response helpers
- update imports for new helper utilities
- adjust legacy tools in Environments domain

## Testing
- `npm run build`