### PR TITLE
Add structured, rich text and single block field support

### DIFF
--- a/src/tools/Schema/Field/Create/handlers/createFieldHandler.ts
+++ b/src/tools/Schema/Field/Create/handlers/createFieldHandler.ts
@@ -27,6 +27,13 @@ export const createFieldHandler = async (args: CreateFieldParams) => {
         "Add { \"structured_text_blocks\": { \"item_types\": [] } } to validators."
       );
     }
+
+    if (field_type === 'single_block' && (!validators || !validators.single_block_blocks)) {
+      return createErrorResponse(
+        "Missing required validator 'single_block_blocks' for single_block field. " +
+        "Add { \"single_block_blocks\": { \"item_types\": [] } } to validators."
+      );
+    }
     
     // String field with string_radio_group/string_select needs enum validator
     if (field_type === 'string' && appearance && 
@@ -225,7 +232,8 @@ function getDefaultEditor(fieldType: string): string {
     lat_lon: "map",
     seo: "seo",
     video: "video",
-    slug: "slug"
+    slug: "slug",
+    single_block: "framed_single_block"
   };
 
   return editorMap[fieldType] || "default_editor";

--- a/src/tools/Schema/FieldCreationHelper/fieldTemplates/index.ts
+++ b/src/tools/Schema/FieldCreationHelper/fieldTemplates/index.ts
@@ -8,6 +8,9 @@ import textTemplates from './textFieldTemplates.js';
 import locationTemplates from './locationFieldTemplates.js';
 import seoTemplates from './seoFieldTemplates.js';
 import jsonTemplates from './jsonFieldTemplates.js';
+import richTextTemplates from './richTextFieldTemplates.js';
+import structuredTextTemplates from './structuredTextFieldTemplates.js';
+import singleBlockTemplates from './singleBlockFieldTemplates.js';
 
 // Define field template structure
 export interface FieldTemplate {
@@ -59,6 +62,15 @@ export const fieldTemplates: FieldTemplatesMap = {
     json_editor: jsonTemplates.jsonEditorTemplate,
     string_multi_select: jsonTemplates.multiSelectTemplate,
     string_checkbox_group: jsonTemplates.checkboxGroupTemplate
+  },
+  rich_text: {
+    rich_text: richTextTemplates.richTextTemplate
+  },
+  structured_text: {
+    structured_text: structuredTextTemplates.structuredTextTemplate
+  },
+  single_block: {
+    framed_single_block: singleBlockTemplates.singleBlockTemplate
   }
 };
 

--- a/src/tools/Schema/FieldCreationHelper/fieldTemplates/richTextFieldTemplates.ts
+++ b/src/tools/Schema/FieldCreationHelper/fieldTemplates/richTextFieldTemplates.ts
@@ -1,0 +1,22 @@
+/**
+ * Templates for rich_text field type
+ */
+
+export const richTextTemplate = {
+  label: "Rich Text Content",
+  api_key: "rich_text_content",
+  field_type: "rich_text",
+  hint: "Rich text content",
+  appearance: {
+    editor: "rich_text",
+    parameters: { start_collapsed: false },
+    addons: []
+  },
+  validators: {
+    rich_text_blocks: { item_types: [] }
+  }
+};
+
+export default {
+  richTextTemplate
+};

--- a/src/tools/Schema/FieldCreationHelper/fieldTemplates/singleBlockFieldTemplates.ts
+++ b/src/tools/Schema/FieldCreationHelper/fieldTemplates/singleBlockFieldTemplates.ts
@@ -1,0 +1,22 @@
+/**
+ * Templates for single_block field type
+ */
+
+export const singleBlockTemplate = {
+  label: "Hero Block",
+  api_key: "hero_block",
+  field_type: "single_block",
+  hint: "Select a single content block",
+  appearance: {
+    editor: "framed_single_block",
+    parameters: { start_collapsed: false },
+    addons: []
+  },
+  validators: {
+    single_block_blocks: { item_types: [] }
+  }
+};
+
+export default {
+  singleBlockTemplate
+};

--- a/src/tools/Schema/FieldCreationHelper/fieldTemplates/structuredTextFieldTemplates.ts
+++ b/src/tools/Schema/FieldCreationHelper/fieldTemplates/structuredTextFieldTemplates.ts
@@ -1,0 +1,22 @@
+/**
+ * Templates for structured_text field type
+ */
+
+export const structuredTextTemplate = {
+  label: "Structured Content",
+  api_key: "structured_content",
+  field_type: "structured_text",
+  hint: "Structured text content",
+  appearance: {
+    editor: "structured_text",
+    parameters: {},
+    addons: []
+  },
+  validators: {
+    structured_text_blocks: { item_types: [] }
+  }
+};
+
+export default {
+  structuredTextTemplate
+};

--- a/src/tools/Schema/FieldCreationHelper/handlers/getFieldTypeInfoHandler.ts
+++ b/src/tools/Schema/FieldCreationHelper/handlers/getFieldTypeInfoHandler.ts
@@ -801,6 +801,76 @@ const fieldTypeDocs = {
         })
       }
     },
+    rich_text: {
+      description: "Rich text content with blocks",
+      validators: {
+        rich_text_blocks: {
+          description: "REQUIRED - allowed block models",
+          example: { item_types: ["block_model_id"] }
+        }
+      },
+      appearances: {
+        rich_text: {
+          description: "Rich text editor",
+          parameters: { start_collapsed: { description: "Start collapsed", default: false } },
+          example: {
+            editor: "rich_text",
+            parameters: { start_collapsed: false },
+            addons: []
+          }
+        }
+      },
+      defaultValue: { description: "Not supported" },
+      fullExample: {
+        label: "Rich Text Content",
+        api_key: "rich_text_content",
+        field_type: "rich_text",
+        hint: "Rich text content",
+        appearance: {
+          editor: "rich_text",
+          parameters: { start_collapsed: false },
+          addons: []
+        },
+        validators: {
+          rich_text_blocks: { item_types: [] }
+        }
+      }
+    },
+    structured_text: {
+      description: "Structured text content",
+      validators: {
+        structured_text_blocks: {
+          description: "REQUIRED - allowed block models",
+          example: { item_types: ["block_model_id"] }
+        }
+      },
+      appearances: {
+        structured_text: {
+          description: "Structured text editor",
+          parameters: {},
+          example: {
+            editor: "structured_text",
+            parameters: {},
+            addons: []
+          }
+        }
+      },
+      defaultValue: { description: "Not supported" },
+      fullExample: {
+        label: "Structured Content",
+        api_key: "structured_content",
+        field_type: "structured_text",
+        hint: "Structured text content",
+        appearance: {
+          editor: "structured_text",
+          parameters: {},
+          addons: []
+        },
+        validators: {
+          structured_text_blocks: { item_types: [] }
+        }
+      }
+    },
     single_block: {
       description: "Single modular content block",
       validators: {

--- a/src/tools/Schema/fieldExamples.ts
+++ b/src/tools/Schema/fieldExamples.ts
@@ -390,3 +390,24 @@ export const structuredTextFieldExample: Field = {
   },
   position: 17
 };
+
+// Single block field
+export const singleBlockFieldExample: Field = {
+  id: 'single_block_field_example',
+  label: 'Hero Block',
+  field_type: 'single_block',
+  api_key: 'hero_block',
+  hint: 'Select a single content block to use as hero',
+  localized: false,
+  validators: {
+    single_block_blocks: {
+      item_types: []
+    }
+  },
+  appearance: {
+    editor: 'framed_single_block',
+    parameters: { start_collapsed: false },
+    addons: []
+  },
+  position: 18
+};

--- a/src/tools/Schema/fieldValidators.ts
+++ b/src/tools/Schema/fieldValidators.ts
@@ -179,6 +179,19 @@ export const itemsNumberValidatorSchema = z.object({
 });
 
 /**
+ * Single block blocks validator
+ * For single_block fields - REQUIRED for single_block fields
+ */
+export const singleBlockBlocksValidatorSchema = z.object({
+  single_block_blocks: z.object({
+    item_types: z.array(z.string())
+      .describe("Array of allowed block model IDs. Can be empty array: []")
+  }).describe(
+    "REQUIRED validator for single_block fields. Example: { \"item_types\": [] }"
+  )
+});
+
+/**
  * Rich text blocks validator
  * For rich_text fields - REQUIRED for rich_text fields
  */
@@ -278,7 +291,7 @@ const requiredValidatorsMap: Record<string, string[]> = {
   structured_text: ['structured_text_blocks'],
   link: ['item_item_type'],
   links: ['items_item_type'],
-  single_block: ['item_item_type'],
+  single_block: ['single_block_blocks'],
   video: ['video_url']
 };
 
@@ -393,7 +406,7 @@ const validatorsMap: ValidatorMapping = {
   ],
   single_block: [
     requiredValidatorSchema,
-    itemItemTypeValidatorSchema
+    singleBlockBlocksValidatorSchema
   ],
   video: [
     requiredValidatorSchema,
@@ -459,5 +472,6 @@ export default {
   structuredTextMarksValidatorSchema,
   structuredTextNodesValidatorSchema,
   dateTimeValidatorSchema,
-  videoUrlValidatorSchema
+  videoUrlValidatorSchema,
+  singleBlockBlocksValidatorSchema
 };


### PR DESCRIPTION
## Summary
- add `single_block_blocks` validator and require it
- map single_block to framed_single_block default editor
- include examples for single_block fields
- provide templates for rich_text, structured_text and single_block fields
- document rich_text, structured_text, and single_block field types

## Testing
- `npm run build`
