### PR TITLE
Improve field docs and templates

### DIFF
--- a/FieldTypeDocs.md
+++ b/FieldTypeDocs.md
@@ -183,6 +183,7 @@ await createField(model, {
    }
    ```
    - DO NOT use `min_lines` or `max_lines` parameters despite documentation
+   - ⚠️ The API often rejects `json_editor` as invalid. Prefer one of the other appearances.
 
 2. **Multi-Select Dropdown (`string_multi_select`):**
    ```javascript
@@ -233,8 +234,13 @@ await createField(model, {
   field_type: "json",
   hint: "Enter JSON data for advanced configuration options",
   appearance: {
-    editor: "json_editor",
-    parameters: {},
+    editor: "string_checkbox_group",
+    parameters: {
+      options: [
+        { label: "Feature A", value: "feature_a" },
+        { label: "Feature B", value: "feature_b" }
+      ]
+    },
     addons: []
   },
   validators: {
@@ -318,6 +324,7 @@ appearance: {
 - String value: `default_value: "default-slug"`
 
 **Complete Example:**
+
 ```javascript
 await createField(model, {
   label: "Page Slug",
@@ -336,6 +343,43 @@ await createField(model, {
   validators: {
     required: {},
     unique: {}
+  }
+});
+```
+
+## Structured Text Field
+
+**Field Type:** `structured_text`
+
+**Required Validators:**
+ - `structured_text_blocks`
+ - `structured_text_links`
+
+**Presentation Options:**
+
+```javascript
+appearance: {
+  editor: "structured_text",
+  parameters: { blocks_start_collapsed: false },
+  addons: []
+}
+```
+
+**Complete Example:**
+
+```javascript
+await createField(model, {
+  label: "Structured Content",
+  api_key: "structured_content",
+  field_type: "structured_text",
+  appearance: {
+    editor: "structured_text",
+    parameters: { blocks_start_collapsed: false },
+    addons: []
+  },
+  validators: {
+    structured_text_blocks: { item_types: [] },
+    structured_text_links: { item_types: [] }
   }
 });
 ```

--- a/docs/FIELD_CREATION_GUIDE.md
+++ b/docs/FIELD_CREATION_GUIDE.md
@@ -98,7 +98,7 @@ The MCP server internally transforms your request into the DatoCMS API v3 format
 
 3. **Editor Names**: Some editor names have important requirements:
    - For `lat_lon` fields, the correct API editor name is `"map"` not `"lat_lon_editor"`
-   - For `json` fields, use `"editor": "json_editor"` not `"json"`
+   - For `json` fields, prefer `"string_multi_select"` or `"string_checkbox_group"` editors; `json_editor` often fails
    - For `link` fields, use `"editor": "link_select"` 
    - For `links` fields, use `"editor": "links_select"`
 
@@ -267,9 +267,32 @@ The MCP server internally transforms your request into the DatoCMS API v3 format
        "parameters": {},
        "addons": []
      },
-     "validators": { "required": {} }
-   }
-   ```
+   "validators": { "required": {} }
+  }
+  ```
+
+### Structured Text Fields
+
+Structured text fields require specific validators and parameters.
+
+```javascript
+{
+  "label": "Structured Content",
+  "api_key": "structured_content",
+  "field_type": "structured_text",
+  "appearance": {
+    "editor": "structured_text",
+    "parameters": { "blocks_start_collapsed": false },
+    "addons": []
+  },
+  "validators": {
+    "structured_text_blocks": { "item_types": [] },
+    "structured_text_links": { "item_types": [] }
+  }
+}
+```
+
+   *Note*: Despite being documented, the `json_editor` appearance is often rejected by the API. Use one of the other appearances if you encounter validation errors.
 
 2. **Multi-Select**:
    ```javascript

--- a/src/tools/Schema/Field/Create/handlers/createFieldHandler.ts
+++ b/src/tools/Schema/Field/Create/handlers/createFieldHandler.ts
@@ -132,9 +132,8 @@ export const createFieldHandler = async (args: CreateFieldParams) => {
 
       if (errorMessage.includes("start_collapsed")) {
         return createErrorResponse(
-          "Invalid parameter 'start_collapsed' for the specified field type's appearance. " +
-          "Make sure you're using the correct parameters for your field type's editor. " +
-          "For rich_text fields, use: { \"editor\": \"rich_text\", \"parameters\": { \"start_collapsed\": false }, \"addons\": [] }"
+          "Invalid parameter 'start_collapsed'. For structured_text use 'blocks_start_collapsed', " +
+          "and for rich_text use: { \"editor\": \"rich_text\", \"parameters\": { \"start_collapsed\": false }, \"addons\": [] }"
         );
       }
     }

--- a/src/tools/Schema/FieldCreationHelper/fieldTemplates/index.ts
+++ b/src/tools/Schema/FieldCreationHelper/fieldTemplates/index.ts
@@ -59,7 +59,6 @@ export const fieldTemplates: FieldTemplatesMap = {
     seo: seoTemplates.seoTemplate
   },
   json: {
-    json_editor: jsonTemplates.jsonEditorTemplate,
     string_multi_select: jsonTemplates.multiSelectTemplate,
     string_checkbox_group: jsonTemplates.checkboxGroupTemplate
   },

--- a/src/tools/Schema/FieldCreationHelper/fieldTemplates/jsonFieldTemplates.ts
+++ b/src/tools/Schema/FieldCreationHelper/fieldTemplates/jsonFieldTemplates.ts
@@ -5,6 +5,8 @@
 
 /**
  * JSON field with json editor appearance
+ * NOTE: The DatoCMS API currently rejects 'json_editor' as invalid. Use one of
+ * the other templates instead.
  */
 export const jsonEditorTemplate = {
   label: "Advanced Settings",

--- a/src/tools/Schema/FieldCreationHelper/fieldTemplates/structuredTextFieldTemplates.ts
+++ b/src/tools/Schema/FieldCreationHelper/fieldTemplates/structuredTextFieldTemplates.ts
@@ -9,11 +9,12 @@ export const structuredTextTemplate = {
   hint: "Structured text content",
   appearance: {
     editor: "structured_text",
-    parameters: {},
+    parameters: { blocks_start_collapsed: false },
     addons: []
   },
   validators: {
-    structured_text_blocks: { item_types: [] }
+    structured_text_blocks: { item_types: [] },
+    structured_text_links: { item_types: [] }
   }
 };
 

--- a/src/tools/Schema/FieldCreationHelper/handlers/getFieldTypeInfoHandler.ts
+++ b/src/tools/Schema/FieldCreationHelper/handlers/getFieldTypeInfoHandler.ts
@@ -842,15 +842,19 @@ const fieldTypeDocs = {
         structured_text_blocks: {
           description: "REQUIRED - allowed block models",
           example: { item_types: ["block_model_id"] }
+        },
+        structured_text_links: {
+          description: "REQUIRED - allowed linked item types",
+          example: { item_types: ["item_model_id"] }
         }
       },
       appearances: {
         structured_text: {
           description: "Structured text editor",
-          parameters: {},
+          parameters: { blocks_start_collapsed: { description: "Start collapsed", default: false } },
           example: {
             editor: "structured_text",
-            parameters: {},
+            parameters: { blocks_start_collapsed: false },
             addons: []
           }
         }
@@ -863,11 +867,12 @@ const fieldTypeDocs = {
         hint: "Structured text content",
         appearance: {
           editor: "structured_text",
-          parameters: {},
+          parameters: { blocks_start_collapsed: false },
           addons: []
         },
         validators: {
-          structured_text_blocks: { item_types: [] }
+          structured_text_blocks: { item_types: [] },
+          structured_text_links: { item_types: [] }
         }
       }
     },
@@ -1026,7 +1031,7 @@ FIELD CREATION TEMPLATES: Use these verified templates to avoid validation error
 1. ALWAYS include 'addons: []' in appearance (mandatory but undocumented)
 2. Use CORRECT editor names:
    - For locations: use "map" (not "lat_lon_editor")
-   - For JSON: use "json_editor" (not "json")
+   - For JSON: prefer "string_multi_select" or "string_checkbox_group" ("json_editor" often fails)
    - For text: include appearance.addons even for "textarea"
 3. String radio/select groups: enum validator values MUST match your option values exactly
 4. JSON checkbox groups: use "options" parameter (not "checkboxes")

--- a/src/tools/Schema/fieldAppearance.ts
+++ b/src/tools/Schema/fieldAppearance.ts
@@ -143,10 +143,17 @@ export const modularContentAppearanceSchema = baseAppearanceSchema.extend({
   parameters: z.object({
     toolbar_options: z.array(z.string()).optional().describe("Toolbar options to include"),
     enable_paste_filters: z.boolean().optional().default(true).describe("Whether to enable paste filters"),
-    start_collapsed: z.boolean().optional().default(false).describe("Whether to start in collapsed state")
+    start_collapsed: z.boolean().optional().default(false).describe("Whether to start in collapsed state"),
+    blocks_start_collapsed: z.boolean().optional().describe(
+      "Whether block nodes should be collapsed by default (structured_text only)"
+    )
   }).optional().default({ start_collapsed: false })
-    .describe("Editor parameters. Example: { \"start_collapsed\": false }")
-}).describe("Appearance for rich text and structured text fields. Example: { \"editor\": \"rich_text\", \"parameters\": { \"start_collapsed\": false }, \"addons\": [] }");
+    .describe(
+      "Editor parameters. Example: { \"start_collapsed\": false, \"blocks_start_collapsed\": false }"
+    )
+}).describe(
+  "Appearance for rich text and structured text fields. Example: { \"editor\": \"rich_text\", \"parameters\": { \"start_collapsed\": false }, \"addons\": [] }"
+);
 
 /**
  * Link field appearance
@@ -206,17 +213,21 @@ export const colorAppearanceSchema = baseAppearanceSchema.extend({
 
 /**
  * JSON field appearance
- * IMPORTANT: For json fields, there are three editor types:
- * 1. "json_editor" - Standard JSON editor
- * 2. "string_multi_select" - Multi-select dropdown
- * 3. "string_checkbox_group" - Multiple checkbox selection (use "options" parameter)
+ * IMPORTANT: For json fields, two stable editor types are supported:
+ * 1. "string_multi_select" - Multi-select dropdown
+ * 2. "string_checkbox_group" - Multiple checkbox selection (use "options" parameter)
+ * The "json_editor" appearance is documented but currently rejected by the API.
  */
 export const jsonAppearanceSchema = baseAppearanceSchema.extend({
-  editor: z.enum(["json_editor", "string_multi_select", "string_checkbox_group"])
-    .describe("Editor type for JSON field. Use 'json_editor' for raw JSON editing, 'string_multi_select' for dropdown multi-select, or 'string_checkbox_group' for checkbox group."),
+  editor: z.enum(["string_multi_select", "string_checkbox_group"])
+    .describe(
+      "Editor type for JSON field. Use 'string_multi_select' for dropdown multi-select or 'string_checkbox_group' for checkbox group."
+    ),
   parameters: z.record(z.unknown()).optional().default({})
     .describe("Editor parameters. For string_checkbox_group, use 'options' not 'checkboxes'. Example for checkbox_group: { \"options\": [{\"label\": \"Option\", \"value\": \"option\"}] }")
-}).describe("Appearance for JSON fields with proper configuration. Example: { \"editor\": \"json_editor\", \"parameters\": {}, \"addons\": [] }");
+}).describe(
+  "Appearance for JSON fields with proper configuration. Example: { \"editor\": \"string_multi_select\", \"parameters\": { \"options\": [] }, \"addons\": [] }"
+);
 
 /**
  * Geo coordinates field appearance
@@ -290,7 +301,7 @@ const fieldTypeToEditorMap: Record<string, string[]> = {
   link: ["link_select"],
   links: ["links_select"],
   color: ["color_picker"],
-  json: ["json_editor", "string_multi_select", "string_checkbox_group"],
+  json: ["string_multi_select", "string_checkbox_group"],
   lat_lon: ["map", "lat_lon_editor"],
   seo: ["seo"],
   video: ["video"],

--- a/src/tools/Schema/fieldExamples.ts
+++ b/src/tools/Schema/fieldExamples.ts
@@ -363,8 +363,13 @@ export const jsonFieldExample: Field = {
   localized: false,
   validators: {},
   appearance: {
-    editor: 'json_editor',
-    parameters: {},
+    editor: 'string_checkbox_group',
+    parameters: {
+      options: [
+        { label: 'Feature A', value: 'feature_a' },
+        { label: 'Feature B', value: 'feature_b' }
+      ]
+    },
     addons: []
   },
   position: 16
@@ -381,11 +386,14 @@ export const structuredTextFieldExample: Field = {
   validators: {
     structured_text_blocks: {
       item_types: []
+    },
+    structured_text_links: {
+      item_types: []
     }
   },
   appearance: {
     editor: 'structured_text',
-    parameters: {},
+    parameters: { blocks_start_collapsed: false },
     addons: []
   },
   position: 17

--- a/src/tools/Schema/schemas.ts
+++ b/src/tools/Schema/schemas.ts
@@ -50,7 +50,7 @@ export const schemaSchemas = {
     environment: environmentSchema.optional().default("main"),
     fieldType: z.string().optional().describe("Optional field type to get specific information about (e.g., 'string', 'text', 'lat_lon', 'json'). If not provided, returns a list of all available field types with their supported appearances."),
     appearance: z.string().optional().describe("Optional appearance type to get specific template for (e.g., 'string_radio_group', 'map', 'string_checkbox_group'). If provided, fieldType must also be provided.")
-  }).describe("Get verified field templates with working configurations to prevent validation errors in DatoCMS. Provides correct structure for problematic field types that commonly fail in creation requests. Includes templates for string_radio_group, string_select, textarea, wysiwyg, markdown, lat_lon, slug, and json fields with various appearances. All templates include the critical 'addons' array, proper editor names, and required validator configurations. For specialized fields, returns specific guidance (e.g., \"Use json_editor instead of json\", \"Use map instead of lat_lon_editor\", \"Remember to match enum validators with option values\")."),
+  }).describe("Get verified field templates with working configurations to prevent validation errors in DatoCMS. Provides correct structure for problematic field types that commonly fail in creation requests. Includes templates for string_radio_group, string_select, textarea, wysiwyg, markdown, lat_lon, slug, and json fields with various appearances. All templates include the critical 'addons' array, proper editor names, and required validator configurations. For specialized fields, returns specific guidance (e.g., \"Use string_multi_select instead of json_editor\", \"Use map instead of lat_lon_editor\", \"Remember to match enum validators with option values\")."),
 
   // ItemType operations
   create_item_type: createBaseSchema().extend({
@@ -208,7 +208,15 @@ export const schemaSchemas = {
       .describe("Validators for the field. CRITICAL VALIDATORS BY TYPE:\n- For string_radio_group/string_select: MUST include { \"enum\": { \"values\": [\"option_a\", \"option_b\"] } } with values matching your options\n- For link fields: MUST include { \"item_item_type\": { \"item_types\": [\"your_item_type_id\"] } }\n- For links fields: MUST include { \"items_item_type\": { \"item_types\": [\"your_item_type_id\"] } }\n- For slug fields: Use { \"required\": {}, \"unique\": {} }\n- For rich_text fields: MUST include { \"rich_text_blocks\": { \"item_types\": [] } }")),
     appearance: z.lazy(() => z.object({
       editor: z.string()
-        .describe("The editor type to use for this field. CRITICAL MAPPINGS:\n- string fields: \"single_line\", \"string_radio_group\", or \"string_select\"\n- text fields: \"textarea\", \"wysiwyg\", or \"markdown\"\n- lat_lon fields: \"map\" (IMPORTANT: use \"map\" not \"lat_lon_editor\")\n- json fields: \"json_editor\", \"string_multi_select\", or \"string_checkbox_group\"\n- link fields: \"link_select\"\n- slug fields: \"slug\"\n- boolean fields: \"boolean\"\n- color fields: \"color_picker\""),
+        .describe(`The editor type to use for this field. CRITICAL MAPPINGS:
+- string fields: "single_line", "string_radio_group", or "string_select"
+- text fields: "textarea", "wysiwyg", or "markdown"
+- lat_lon fields: "map" (IMPORTANT: use "map" not "lat_lon_editor")
+- json fields: "string_multi_select" or "string_checkbox_group" (json_editor currently fails)
+- link fields: "link_select"
+- slug fields: "slug"
+- boolean fields: "boolean"
+- color fields: "color_picker"`),
       parameters: z.record(z.unknown()).default({})
         .describe("Editor-specific parameters. Common examples:\n- For string_radio_group: { \"radios\": [{\"label\": \"Option A\", \"value\": \"option_a\"}] }\n- For string_select: { \"options\": [{\"label\": \"Option A\", \"value\": \"option_a\"}] }\n- For string_checkbox_group: { \"options\": [{\"label\": \"Feature\", \"value\": \"feature\"}] } (not \"checkboxes\")\n- For slug: { \"url_prefix\": \"https://example.com/\" }"),
       addons: z.array(fieldAddonSchema).default([])


### PR DESCRIPTION
## Summary
- clarify JSON editor issues across docs
- document structured text blocks/links validators and blocks_start_collapsed
- remove json_editor from default templates
- update error messaging for start_collapsed
- expand helper templates and docs with structured text examples

## Testing
- `npm run build`
- `npm test` *(fails: no test specified)*