### PR TITLE
Address field type doc issues

### DIFF
--- a/FieldTypeDocs.md
+++ b/FieldTypeDocs.md
@@ -306,6 +306,7 @@ await createField(model, {
 **Valid Validators:**
 - `required: {}`
 - `unique: {}`
+- `slug_title_field: { title_field_id: "title_field_id" }`
 
 **Presentation Options:**
 ```javascript
@@ -343,10 +344,44 @@ await createField(model, {
   validators: {
     required: {},
     unique: {}
+    slug_title_field: { title_field_id: "title_field_id" }
   }
 });
 ```
 
+
+## Rich Text Field
+
+**Field Type:** `rich_text`
+
+**Required Validators:**
+ - `rich_text_blocks`
+
+**Presentation Options:**
+```javascript
+appearance: {
+  editor: "rich_text",
+  parameters: { start_collapsed: false },
+  addons: []
+}
+```
+
+**Complete Example:**
+```javascript
+await createField(model, {
+  label: "Rich Text Content",
+  api_key: "rich_text_content",
+  field_type: "rich_text",
+  appearance: {
+    editor: "rich_text",
+    parameters: { start_collapsed: false },
+    addons: []
+  },
+  validators: {
+    rich_text_blocks: { item_types: [] }
+  }
+});
+```
 ## Structured Text Field
 
 **Field Type:** `structured_text`

--- a/docs/FIELD_CREATION_GUIDE.md
+++ b/docs/FIELD_CREATION_GUIDE.md
@@ -236,6 +236,7 @@ The MCP server internally transforms your request into the DatoCMS API v3 format
      "validators": {
        "required": {},
        "unique": {}
+      "slug_title_field": { "title_field_id": "title_field_id" }
      }
    }
    ```
@@ -271,6 +272,25 @@ The MCP server internally transforms your request into the DatoCMS API v3 format
   }
   ```
 
+### Rich Text Fields
+
+Rich text fields require the `rich_text_blocks` validator and a few key parameters.
+
+```javascript
+{
+  "label": "Rich Text Content",
+  "api_key": "rich_text_content",
+  "field_type": "rich_text",
+  "appearance": {
+    "editor": "rich_text",
+    "parameters": { "start_collapsed": false },
+    "addons": []
+  },
+  "validators": {
+    "rich_text_blocks": { "item_types": [] }
+  }
+}
+```
 ### Structured Text Fields
 
 Structured text fields require specific validators and parameters.

--- a/src/tools/Schema/FieldCreationHelper/fieldTemplates/seoFieldTemplates.ts
+++ b/src/tools/Schema/FieldCreationHelper/fieldTemplates/seoFieldTemplates.ts
@@ -21,7 +21,8 @@ export const slugTemplate = {
   },
   validators: {
     required: {},
-    unique: {}
+    unique: {},
+    slug_title_field: { title_field_id: "title_field_id" }
   }
 };
 


### PR DESCRIPTION
## Summary
- document required `slug_title_field` validator for slug fields
- add rich text field examples
- include slug title validator in slug template

## Testing
- `npm run build`