### PR TITLE
Fix single_block start_collapsed issue

### DIFF
--- a/fieldCreationExamplesAllTypesAndAppearencesAndDocumentationInComments.js
+++ b/fieldCreationExamplesAllTypesAndAppearencesAndDocumentationInComments.js
@@ -510,13 +510,8 @@ previews	Array<String>	✅	Specify which previews should be visible to editors. 
 rich_text
 Built-in editor for Modular content fields.
 
-Parameter	Type	Required	Description
-start_collapsed	Boolean		Whether you want block records collapsed by default or not
 framed_single_block
-Built-in editor for Single block fields.
-
-Parameter	Type	Required	Description
-start_collapsed	Boolean		Whether you want block record collapsed by default or not
+Built-in editor for Single block fields. No additional parameters are required.
 structured_text
 Built-in editor for Structured text fields.
 

--- a/src/tools/Schema/Field/Create/handlers/createFieldHandler.ts
+++ b/src/tools/Schema/Field/Create/handlers/createFieldHandler.ts
@@ -165,8 +165,9 @@ export const createFieldHandler = async (args: CreateFieldParams) => {
 
       if (errorMessage.includes("start_collapsed")) {
         return createErrorResponse(
-          "Invalid parameter 'start_collapsed'. For structured_text use 'blocks_start_collapsed', " +
-          "and for rich_text use: { \"editor\": \"rich_text\", \"parameters\": { \"start_collapsed\": false }, \"addons\": [] }"
+          "The 'start_collapsed' parameter is only valid for rich_text fields (as 'start_collapsed') " +
+          "and structured_text fields (as 'blocks_start_collapsed'). " +
+          "Single_block fields do not support collapsed parameters. Remove 'start_collapsed' from the appearance."
         );
       }
 

--- a/src/tools/Schema/FieldCreationHelper/fieldTemplates/singleBlockFieldTemplates.ts
+++ b/src/tools/Schema/FieldCreationHelper/fieldTemplates/singleBlockFieldTemplates.ts
@@ -9,7 +9,7 @@ export const singleBlockTemplate = {
   hint: "Select a single content block",
   appearance: {
     editor: "framed_single_block",
-    parameters: { start_collapsed: false },
+    parameters: {},
     addons: []
   },
   validators: {

--- a/src/tools/Schema/FieldCreationHelper/handlers/getFieldTypeInfoHandler.ts
+++ b/src/tools/Schema/FieldCreationHelper/handlers/getFieldTypeInfoHandler.ts
@@ -889,12 +889,10 @@ const fieldTypeDocs = {
       appearances: {
         framed_single_block: {
           description: "Block editor with frame",
-          parameters: {
-            start_collapsed: { description: "Whether the block is initially collapsed", default: false }
-          },
+          parameters: {},
           example: {
             editor: "framed_single_block",
-            parameters: { start_collapsed: false },
+            parameters: {},
             addons: []
           }
         }
@@ -910,7 +908,7 @@ const fieldTypeDocs = {
         hint: "Select a single content block to use as hero",
         appearance: {
           editor: "framed_single_block",
-          parameters: { start_collapsed: false },
+          parameters: {},
           addons: []
         },
         validators: {

--- a/src/tools/Schema/fieldExamples.ts
+++ b/src/tools/Schema/fieldExamples.ts
@@ -414,7 +414,7 @@ export const singleBlockFieldExample: Field = {
   },
   appearance: {
     editor: 'framed_single_block',
-    parameters: { start_collapsed: false },
+    parameters: {},
     addons: []
   },
   position: 18


### PR DESCRIPTION
## Summary
- remove `start_collapsed` from single_block templates and docs
- clarify `start_collapsed` error message for field creation

## Testing
- `npm test` *(fails: Error: no test specified)*