### PR TITLE
Fix single block field template

### DIFF
--- a/docs/FIELD_CREATION_GUIDE.md
+++ b/docs/FIELD_CREATION_GUIDE.md
@@ -350,9 +350,29 @@ Structured text fields require specific validators and parameters.
        },
        "addons": []
      },
-     "validators": { "required": {} }
-   }
-   ```
+    "validators": { "required": {} }
+  }
+  ```
+
+### Single Block Fields
+
+Single block fields allow editors to select a single modular block record. The `start_collapsed` parameter controls whether the block editor is collapsed by default.
+
+```javascript
+{
+  "label": "Hero Block",
+  "api_key": "hero_block",
+  "field_type": "single_block",
+  "appearance": {
+    "editor": "framed_single_block",
+    "parameters": { "start_collapsed": false },
+    "addons": []
+  },
+  "validators": {
+    "single_block_blocks": { "item_types": [] }
+  }
+}
+```
 
 ## Reference Fields
 

--- a/src/tools/Schema/Field/Create/handlers/createFieldHandler.ts
+++ b/src/tools/Schema/Field/Create/handlers/createFieldHandler.ts
@@ -111,15 +111,6 @@ export const createFieldHandler = async (args: CreateFieldParams) => {
       };
     }
 
-    // Remove unsupported parameters for single_block fields
-    if (field_type === 'single_block' && processedAppearance?.parameters) {
-      const { start_collapsed, ...restParams } = processedAppearance.parameters as any;
-      processedAppearance = {
-        ...processedAppearance,
-        parameters: restParams
-      };
-    }
-
     // Build the DatoCMS client
     const client = getClient(apiToken, environment);
 
@@ -174,9 +165,9 @@ export const createFieldHandler = async (args: CreateFieldParams) => {
 
       if (errorMessage.includes("start_collapsed")) {
         return createErrorResponse(
-          "The 'start_collapsed' parameter is only valid for rich_text fields (as 'start_collapsed') " +
-          "and structured_text fields (as 'blocks_start_collapsed'). " +
-          "Single_block fields do not support collapsed parameters. Remove 'start_collapsed' from the appearance."
+          "The 'start_collapsed' parameter is valid for rich_text and single_block fields. " +
+          "For structured_text fields use 'blocks_start_collapsed'. " +
+          "Ensure you only include this parameter with the appropriate field types."
         );
       }
 

--- a/src/tools/Schema/FieldCreationHelper/fieldTemplates/singleBlockFieldTemplates.ts
+++ b/src/tools/Schema/FieldCreationHelper/fieldTemplates/singleBlockFieldTemplates.ts
@@ -9,7 +9,7 @@ export const singleBlockTemplate = {
   hint: "Select a single content block",
   appearance: {
     editor: "framed_single_block",
-    parameters: {},
+    parameters: { start_collapsed: false },
     addons: []
   },
   validators: {

--- a/src/tools/Schema/FieldCreationHelper/handlers/getFieldTypeInfoHandler.ts
+++ b/src/tools/Schema/FieldCreationHelper/handlers/getFieldTypeInfoHandler.ts
@@ -889,10 +889,10 @@ const fieldTypeDocs = {
       appearances: {
         framed_single_block: {
           description: "Block editor with frame",
-          parameters: {},
+          parameters: { start_collapsed: { description: "Start collapsed", default: false } },
           example: {
             editor: "framed_single_block",
-            parameters: {},
+            parameters: { start_collapsed: false },
             addons: []
           }
         }
@@ -908,7 +908,7 @@ const fieldTypeDocs = {
         hint: "Select a single content block to use as hero",
         appearance: {
           editor: "framed_single_block",
-          parameters: {},
+          parameters: { start_collapsed: false },
           addons: []
         },
         validators: {

--- a/src/tools/Schema/fieldAppearance.ts
+++ b/src/tools/Schema/fieldAppearance.ts
@@ -232,9 +232,21 @@ export const singleBlockAppearanceSchema = baseAppearanceSchema.extend({
   editor: z.enum(["framed_single_block", "frameless_single_block"]).describe(
     "Editor type for single_block fields. Use 'framed_single_block' or 'frameless_single_block'."
   ),
-  parameters: z.object({}).optional().default({}).describe("No additional parameters required")
+  parameters: z
+    .object({
+      start_collapsed: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Whether you want the block collapsed by default")
+    })
+    .optional()
+    .default({ start_collapsed: false })
+    .describe(
+      "Editor parameters for single block fields. Example: { \"start_collapsed\": false }"
+    )
 }).describe(
-  "Appearance for single_block fields. Example: { \"editor\": \"framed_single_block\", \"parameters\": {}, \"addons\": [] }"
+  "Appearance for single_block fields. Example: { \"editor\": \"framed_single_block\", \"parameters\": { \"start_collapsed\": false }, \"addons\": [] }"
 );
 
 /**

--- a/src/tools/Schema/fieldExamples.ts
+++ b/src/tools/Schema/fieldExamples.ts
@@ -414,7 +414,7 @@ export const singleBlockFieldExample: Field = {
   },
   appearance: {
     editor: 'framed_single_block',
-    parameters: {},
+    parameters: { start_collapsed: false },
     addons: []
   },
   position: 18


### PR DESCRIPTION
## Summary
- allow `start_collapsed` parameter for single block fields
- include this parameter in single block templates and examples
- document single block field usage in the guide
- improve error message for `start_collapsed`

## Testing
- `npm run build`
