### PR TITLE
Update code to enforce validator restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ When creating fields in DatoCMS, follow these critical requirements:
 6. Structured text fields require both `structured_text_blocks` and `structured_text_links` validators
 7. Slug fields need a `slug_title_field` validator referencing the title field
 8. Single block fields use the `single_block_blocks` validator
+9. The `required` validator is **not** supported on `gallery`, `links`, or `rich_text` fields
 
 See `docs/FIELD_CREATION_GUIDE.md` for detailed examples and requirements.
 

--- a/docs/FIELD_CREATION_GUIDE.md
+++ b/docs/FIELD_CREATION_GUIDE.md
@@ -96,6 +96,8 @@ The MCP server internally transforms your request into the DatoCMS API v3 format
 
 11. **Slug Fields**: Require a `slug_title_field` validator referencing the title field.
 
+12. The `required` validator is not supported on `gallery`, `links`, or `rich_text` fields. Remove it when creating these field types.
+
 ## Critical Requirements for All Fields
 
 1. **Appearance Structure**: All field appearances must have this structure:
@@ -467,6 +469,7 @@ before you add a link or links field referencing them.
    - Missing or mismatched `enum` validator values for dropdown/radio fields
    - Using the wrong editor name for certain field types
    - Parameter structure issues (e.g., using `checkboxes` instead of `options`)
+   - Applying the `required` validator to `gallery`, `links`, or `rich_text` fields
 
 2. **Default Values**:
    - Avoid setting default values for localized fields

--- a/src/tools/Schema/Field/Create/handlers/createFieldHandler.ts
+++ b/src/tools/Schema/Field/Create/handlers/createFieldHandler.ts
@@ -126,6 +126,17 @@ export const createFieldHandler = async (args: CreateFieldParams) => {
       );
     }
 
+    // 'required' validator not allowed on some field types
+    if (
+      validators &&
+      (validators as any).required !== undefined &&
+      (field_type === 'gallery' || field_type === 'links' || field_type === 'rich_text')
+    ) {
+      return createErrorResponse(
+        "The 'required' validator is not supported on gallery, links, or rich_text fields. Remove it from the validators object."
+      );
+    }
+
     // Ensure addons array is present
     let processedAppearance = appearance;
     if (appearance && !appearance.addons) {

--- a/src/tools/Schema/fieldExamples.ts
+++ b/src/tools/Schema/fieldExamples.ts
@@ -229,7 +229,6 @@ export const multiLinkFieldExample: Field = {
   hint: 'Select related articles to display',
   localized: false,
   validators: {
-    required: {},
     items_item_type: {
       item_types: ['article']
     }
@@ -277,7 +276,6 @@ export const multipleAssetFieldExample: Field = {
   hint: 'Image gallery',
   localized: false,
   validators: {
-    required: {},
     file_size: {
       max_size: 5000000
     }

--- a/src/tools/Schema/fieldValidators.ts
+++ b/src/tools/Schema/fieldValidators.ts
@@ -356,7 +356,6 @@ const validatorsMap: ValidatorMapping = {
     imageDimensionValidatorSchema
   ],
   gallery: [
-    requiredValidatorSchema,
     fileSizeValidatorSchema,
     fileTypeValidatorSchema,
     imageDimensionValidatorSchema,
@@ -369,7 +368,6 @@ const validatorsMap: ValidatorMapping = {
     itemItemTypeValidatorSchema
   ],
   links: [
-    requiredValidatorSchema,
     itemItemTypeValidatorSchema,
     itemsNumberValidatorSchema
   ],


### PR DESCRIPTION
## Summary
- prevent using the `required` validator on gallery, links, and rich_text fields in the create field handler
- remove `required` validator from gallery and links example schemas
- adjust validator map so gallery and links fields no longer list `required`

## Testing
- `npm test` *(fails: no test specified)*