### PR TITLE
Clarify multiple block IDs for rich text

### DIFF
--- a/FieldTypeDocs.md
+++ b/FieldTypeDocs.md
@@ -355,7 +355,9 @@ await createField(model, {
 **Field Type:** `rich_text`
 
 **Required Validators:**
- - `rich_text_blocks`
+- `rich_text_blocks`
+
+The `item_types` array can include one or more block model IDs.
 
 **Presentation Options:**
 ```javascript
@@ -378,7 +380,7 @@ await createField(model, {
     addons: []
   },
   validators: {
-    rich_text_blocks: { item_types: [] }
+    rich_text_blocks: { item_types: ["block_model_id1", "block_model_id2"] }
   }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ When creating fields in DatoCMS, follow these critical requirements:
 2. For location fields, use `"editor": "map"` (not "lat_lon_editor")
 3. String fields with radio or select appearance require matching enum validator values
 4. JSON fields with checkbox group must use the "options" parameter
-5. Rich text fields require a `rich_text_blocks` validator
+5. Rich text fields require a `rich_text_blocks` validator specifying the allowed block item type IDs. The `item_types` array can contain one or more block model IDs
 6. Structured text fields require both `structured_text_blocks` and `structured_text_links` validators
 7. Slug fields need a `slug_title_field` validator referencing the title field
 8. Single block fields use the `single_block_blocks` validator

--- a/docs/FIELD_CREATION_GUIDE.md
+++ b/docs/FIELD_CREATION_GUIDE.md
@@ -86,7 +86,7 @@ The MCP server internally transforms your request into the DatoCMS API v3 format
 
 6. **Single Line String Fields**: Include `heading: false` in the appearance parameters.
 
-7. **Rich Text Fields**: Always include a `rich_text_blocks` validator, even if the item type array is empty.
+7. **Rich Text Fields**: Always include a `rich_text_blocks` validator **with the block item type IDs allowed in the field**. The `item_types` array can include one or more IDs. Example: `{ "rich_text_blocks": { "item_types": ["block_model_id1", "block_model_id2"] } }`.
 
 8. **Structured Text Fields**: Must include both `structured_text_blocks` and `structured_text_links` validators.
 
@@ -326,7 +326,7 @@ is for structured text fields).
     "addons": []
   },
   "validators": {
-    "rich_text_blocks": { "item_types": [] }
+    "rich_text_blocks": { "item_types": ["block_model_id1", "block_model_id2"] }
   }
 }
 ```

--- a/src/tools/Schema/Field/Create/handlers/createFieldHandler.ts
+++ b/src/tools/Schema/Field/Create/handlers/createFieldHandler.ts
@@ -17,7 +17,7 @@ export const createFieldHandler = async (args: CreateFieldParams) => {
     if (field_type === 'rich_text' && (!validators || !validators.rich_text_blocks)) {
       return createErrorResponse(
         "Missing required validator 'rich_text_blocks' for rich_text field. " +
-        "Add { \"rich_text_blocks\": { \"item_types\": [] } } to validators."
+        "Add { \"rich_text_blocks\": { \"item_types\": [\"block_model_id1\", \"block_model_id2\"] } } to validators."
       );
     }
 
@@ -233,7 +233,7 @@ export const createFieldHandler = async (args: CreateFieldParams) => {
       if (errorMessage.includes("rich_text_blocks")) {
         return createErrorResponse(
           "Rich text fields require the 'rich_text_blocks' validator. " +
-          "Example: { \"rich_text_blocks\": { \"item_types\": [] } }"
+          "Example: { \"rich_text_blocks\": { \"item_types\": [\"block_model_id1\", \"block_model_id2\"] } }"
         );
       }
 

--- a/src/tools/Schema/FieldCreationHelper/fieldTemplates/richTextFieldTemplates.ts
+++ b/src/tools/Schema/FieldCreationHelper/fieldTemplates/richTextFieldTemplates.ts
@@ -13,7 +13,7 @@ export const richTextTemplate = {
     addons: []
   },
   validators: {
-    rich_text_blocks: { item_types: [] }
+    rich_text_blocks: { item_types: ["block_model_id1", "block_model_id2"] }
   }
 };
 

--- a/src/tools/Schema/FieldCreationHelper/handlers/getFieldTypeInfoHandler.ts
+++ b/src/tools/Schema/FieldCreationHelper/handlers/getFieldTypeInfoHandler.ts
@@ -806,7 +806,7 @@ const fieldTypeDocs = {
       validators: {
         rich_text_blocks: {
           description: "REQUIRED - allowed block models",
-          example: { item_types: ["block_model_id"] }
+          example: { item_types: ["block_model_id1", "block_model_id2"] }
         }
       },
       appearances: {
@@ -832,7 +832,7 @@ const fieldTypeDocs = {
           addons: []
         },
         validators: {
-          rich_text_blocks: { item_types: [] }
+          rich_text_blocks: { item_types: ["block_model_id1", "block_model_id2"] }
         }
       }
     },
@@ -841,7 +841,7 @@ const fieldTypeDocs = {
       validators: {
         structured_text_blocks: {
           description: "REQUIRED - allowed block models",
-          example: { item_types: ["block_model_id"] }
+          example: { item_types: ["block_model_id1", "block_model_id2"] }
         },
         structured_text_links: {
           description: "REQUIRED - allowed linked item types",

--- a/src/tools/Schema/fieldValidators.ts
+++ b/src/tools/Schema/fieldValidators.ts
@@ -198,8 +198,8 @@ export const singleBlockBlocksValidatorSchema = z.object({
 export const richTextBlocksValidatorSchema = z.object({
   rich_text_blocks: z.object({
     item_types: z.array(z.string())
-      .describe("Array of allowed block item type IDs. Can be empty array: []")
-  }).describe("REQUIRED validator for rich_text fields. Example: { \"item_types\": [] }")
+      .describe("Array of allowed block item type IDs (one or more).")
+  }).describe("REQUIRED validator for rich_text fields. Example: { \"item_types\": [\"block_model_id1\", \"block_model_id2\"] }")
 });
 
 /**
@@ -439,7 +439,7 @@ function getExampleValidator(fieldType: string): string {
     case 'text':
       return '{ "required": {}, "length": { "max": 1000 } }';
     case 'rich_text':
-      return '{ "rich_text_blocks": { "item_types": [] } }';
+      return '{ "rich_text_blocks": { "item_types": ["block_model_id1", "block_model_id2"] } }';
     case 'link':
       return '{ "required": {}, "item_item_type": { "item_types": ["blog_post"] } }';
     case 'file':

--- a/src/tools/Schema/schemas.ts
+++ b/src/tools/Schema/schemas.ts
@@ -205,7 +205,7 @@ export const schemaSchemas = {
     field_type: fieldTypeSchema
       .describe("The type of field to create. Each type requires specific validators and appearance configurations."),
     validators: z.lazy(() => z.record(z.unknown())
-      .describe("Validators for the field. CRITICAL VALIDATORS BY TYPE:\n- For string_radio_group/string_select: MUST include { \"enum\": { \"values\": [\"option_a\", \"option_b\"] } } with values matching your options\n- For link fields: MUST include { \"item_item_type\": { \"item_types\": [\"your_item_type_id\"] } }\n- For links fields: MUST include { \"items_item_type\": { \"item_types\": [\"your_item_type_id\"] } }\n- For slug fields: Use { \"required\": {}, \"unique\": {} }\n- For rich_text fields: MUST include { \"rich_text_blocks\": { \"item_types\": [] } }")),
+      .describe("Validators for the field. CRITICAL VALIDATORS BY TYPE:\n- For string_radio_group/string_select: MUST include { \"enum\": { \"values\": [\"option_a\", \"option_b\"] } } with values matching your options\n- For link fields: MUST include { \"item_item_type\": { \"item_types\": [\"your_item_type_id\"] } }\n- For links fields: MUST include { \"items_item_type\": { \"item_types\": [\"your_item_type_id\"] } }\n- For slug fields: Use { \"required\": {}, \"unique\": {} }\n- For rich_text fields: MUST include { \"rich_text_blocks\": { \"item_types\": [\"block_model_id1\", \"block_model_id2\"] } }")),
     appearance: z.lazy(() => z.object({
       editor: z.string()
         .describe(`The editor type to use for this field. CRITICAL MAPPINGS:


### PR DESCRIPTION
## Summary
- document that `rich_text_blocks.item_types` can contain multiple IDs
- update examples and templates to show several block IDs
- adjust validation messages accordingly

## Testing
- `npm run build`
