### PR TITLE
Rename record_editor_url action to record_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The server follows a modular router-based architecture:
 | `WebhookAndBuildTriggerCallsAndDeploysRouterTool` | Webhook and build management |
 | `UIRouterTool` | UI customization tools |
 
+The records router includes a `record_url` action for building the editor URL of a specific record.
+
 ## Getting Started
 
 ### Prerequisites

--- a/src/tools/Records/EnhancedRecordsRouterTool.ts
+++ b/src/tools/Records/EnhancedRecordsRouterTool.ts
@@ -47,7 +47,7 @@ type ActionArgsMap = {
   query: z.infer<typeof recordsSchemas.query>;
   get: z.infer<typeof recordsSchemas.get>;
   references: z.infer<typeof recordsSchemas.references>;
-  editor_url_from_type: z.infer<typeof recordsSchemas.editor_url_from_type>;
+  record_url: z.infer<typeof recordsSchemas.record_url>;
   create: z.infer<typeof recordsSchemas.create>;
   update: z.infer<typeof recordsSchemas.update>;
   duplicate: z.infer<typeof recordsSchemas.duplicate>;
@@ -145,8 +145,8 @@ This will show you all the required parameters and their types.`);
               return getRecordByIdHandler(actionArgs as ActionArgsMap['get']);
             case "references":
               return getRecordReferencesHandler(actionArgs as ActionArgsMap['references']);
-            case "editor_url_from_type":
-              return buildRecordEditorUrlFromTypeHandler(actionArgs as ActionArgsMap['editor_url_from_type']);
+            case "record_url":
+              return buildRecordEditorUrlFromTypeHandler(actionArgs as ActionArgsMap['record_url']);
             case "create":
               return createRecordHandler(actionArgs as ActionArgsMap['create']);
             case "update":

--- a/src/tools/Records/Read/handlers/buildRecordEditorUrlFromTypeHandler.ts
+++ b/src/tools/Records/Read/handlers/buildRecordEditorUrlFromTypeHandler.ts
@@ -12,7 +12,7 @@ import type { recordsSchemas } from "../../schemas.js";
  * Handler to build the editor URL for a specific DatoCMS record using project URL and item type
  * Extracted from the BuildDatoCMSRecordUrl tool
  */
-export const buildRecordEditorUrlFromTypeHandler = async (args: z.infer<typeof recordsSchemas.editor_url_from_type>) => {
+export const buildRecordEditorUrlFromTypeHandler = async (args: z.infer<typeof recordsSchemas.record_url>) => {
   const { projectUrl, itemTypeId, itemId, environment } = args;
   
   try {

--- a/src/tools/Records/RecordsRouterTool.ts
+++ b/src/tools/Records/RecordsRouterTool.ts
@@ -45,7 +45,7 @@ type ActionArgsMap = {
   query: z.infer<typeof recordsSchemas.query>;
   get: z.infer<typeof recordsSchemas.get>;
   references: z.infer<typeof recordsSchemas.references>;
-  editor_url_from_type: z.infer<typeof recordsSchemas.editor_url_from_type>;
+  record_url: z.infer<typeof recordsSchemas.record_url>;
   create: z.infer<typeof recordsSchemas.create>;
   update: z.infer<typeof recordsSchemas.update>;
   duplicate: z.infer<typeof recordsSchemas.duplicate>;
@@ -131,8 +131,8 @@ This will show you all the required parameters and their types.`);
               return getRecordByIdHandler(validatedArgs as ActionArgsMap['get']);
             case "references":
               return getRecordReferencesHandler(validatedArgs as ActionArgsMap['references']);
-            case "editor_url_from_type":
-              return buildRecordEditorUrlFromTypeHandler(validatedArgs as ActionArgsMap['editor_url_from_type']);
+            case "record_url":
+              return buildRecordEditorUrlFromTypeHandler(validatedArgs as ActionArgsMap['record_url']);
             case "create":
               return createRecordHandler(validatedArgs as ActionArgsMap['create']);
             case "update":

--- a/src/tools/Records/schemas.ts
+++ b/src/tools/Records/schemas.ts
@@ -26,6 +26,21 @@ const recordIdSchema = z.string()
   .describe("The ID of the specific DatoCMS record.");
 
 /**
+ * Schema for building a record editor URL using project URL and item type
+ */
+const recordEditorUrlSchema = z.object({
+  projectUrl: z.string()
+    .describe(
+      "DatoCMS project URL. If the user did not provide one yet, use the datocms_project tool with action 'get_info' to retrieve it. The URL will be under the internal_domain property."
+    ),
+  itemTypeId: z.string().describe(
+    "The item type ID from DatoCMS, typically available in the item.item_type.id property of a record."
+  ),
+  itemId: recordIdSchema,
+  environment: environmentSchema,
+});
+
+/**
  * Schemas for all record-related actions.
  * These schemas are extracted from the original record tool definitions
  * and are used for both the records router and describe tools.
@@ -74,14 +89,7 @@ export const recordsSchemas = {
       .describe("If true, returns only an array of record IDs instead of complete records. Use this to save on tokens and context window space when only IDs are needed. Default is true."),
   }),
 
-  editor_url_from_type: z.object({ 
-    projectUrl: z.string()
-      .describe("DatoCMS project URL. If the user did not provide one yet, use the datocms_project tool with action 'get_info' to retrieve it. The URL will be under the internal_domain property."),
-    itemTypeId: z.string()
-      .describe("The item type ID from DatoCMS, typically available in the item.item_type.id property of a record."),
-    itemId: recordIdSchema,
-    environment: environmentSchema
-  }),
+  record_url: recordEditorUrlSchema,
 
   // Create operations
   create: createBaseSchema().extend({


### PR DESCRIPTION
## Summary
- rename alias `record_editor_url` and original `editor_url_from_type` to a single `record_url` action
- update routers and handler type definitions
- document the new `record_url` action

## Testing
- `npm run build`
- `node -e "const {recordActionsList}=require('./dist/tools/Records/schemas.js'); console.log(recordActionsList.includes('record_url'));"`