### PR TITLE
Fix records client list methods

### DIFF
--- a/src/tools/Records/typedClient.ts
+++ b/src/tools/Records/typedClient.ts
@@ -83,7 +83,7 @@ export class TypedRecordsClient {
    * @returns Array of records
    */
   async listRecords(params?: Partial<RecordQueryParams>): Promise<Item[]> {
-    return this.client.items.all(params as any);
+    return this.client.items.list(params as any);
   }
   
   /**
@@ -156,7 +156,7 @@ export class TypedRecordsClient {
    * @returns Array of versions
    */
   async listRecordVersions(itemId: string): Promise<ItemVersion[]> {
-    return this.client.itemVersions.all({ item_id: itemId });
+    return this.client.itemVersions.list(itemId);
   }
   
   /**


### PR DESCRIPTION
## Summary
- update typed records client to use `list` instead of the non-existent `all` for both records and record versions

## Testing
- `npm run build`