### PR TITLE
Add directory structure validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ When extending this codebase:
 3. Implement handlers in domain-specific directories
 4. Register new tools in `src/index.ts`
 
+## Directory Structure Validation
+
+Run `npm run validate` to verify that all domain folders follow the
+expected pattern. The script checks operation directory names and ensures
+each operation and its `handlers` folder contain the required `index.ts`.
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "start:http": "TRANSPORT_TYPE=http node dist/index.js",
-    "dev": "tsc -w"
+    "dev": "tsc -w",
+    "validate": "node dist/scripts/validate-structure.js"
   },
   "keywords": [
     "mcp",

--- a/scripts/validate-structure.ts
+++ b/scripts/validate-structure.ts
@@ -1,0 +1,70 @@
+import { readdir, access, stat } from 'fs/promises';
+import path from 'path';
+
+const TOOLS_DIR = path.join(process.cwd(), 'src', 'tools');
+
+function isPascalCase(name: string): boolean {
+  return /^[A-Z][A-Za-z0-9]*$/.test(name);
+}
+
+async function validate() {
+  const domains = await readdir(TOOLS_DIR, { withFileTypes: true });
+  let hasError = false;
+
+  for (const domain of domains) {
+    if (!domain.isDirectory()) continue;
+    const domainPath = path.join(TOOLS_DIR, domain.name);
+    const entries = await readdir(domainPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const opName = entry.name;
+
+      if (!isPascalCase(opName)) {
+        console.error(`Invalid operation directory name: ${domain.name}/${opName}`);
+        hasError = true;
+      }
+
+      const opPath = path.join(domainPath, opName);
+      const opIndex = path.join(opPath, 'index.ts');
+      try {
+        await access(opIndex);
+      } catch {
+        console.error(`Missing index.ts in ${domain.name}/${opName}`);
+        hasError = true;
+      }
+
+      const handlersPath = path.join(opPath, 'handlers');
+      try {
+        const hstat = await stat(handlersPath);
+        if (!hstat.isDirectory()) {
+          console.error(`Missing handlers directory in ${domain.name}/${opName}`);
+          hasError = true;
+        } else {
+          const handlersIndex = path.join(handlersPath, 'index.ts');
+          try {
+            await access(handlersIndex);
+          } catch {
+            console.error(`Missing handlers/index.ts in ${domain.name}/${opName}`);
+            hasError = true;
+          }
+        }
+      } catch {
+        console.error(`Missing handlers directory in ${domain.name}/${opName}`);
+        hasError = true;
+      }
+    }
+  }
+
+  if (hasError) {
+    console.error('Directory structure validation failed.');
+    process.exit(1);
+  } else {
+    console.log('Directory structure validation passed.');
+  }
+}
+
+validate().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -110,6 +110,6 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "scripts/**/*"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- create `scripts/validate-structure.ts` to verify domain operation folders
- compile scripts in `tsconfig.json`
- expose `npm run validate` command
- document validation script usage in README

## Testing
- `npm run build`
- `npm run validate` *(fails: Directory structure validation failed)*